### PR TITLE
Removed some redundant assertions about the libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,16 @@ Our objective is to feature cross-platform libraries, designed for wherever Swif
 > _Tags: autocomplete, metaprogramming, templates, linting_
 * [langserver-swift](https://github.com/RLovelett/langserver-swift): a Swift implementation of the open **Language Server Protocol**. Linux port on the [making](https://github.com/RLovelett/langserver-swift/pull/36).
 * [SourceKittenDaemon](https://github.com/terhechte/SourceKittenDaemon): **Swift auto-completions** for any text editor. Linux port in progress.
-* [Swift Development Environment](https://github.com/vknabel/vscode-swift-development-environment): a vscode plugin for Swift including **autocompletion**. Supports Linux and Darwin.
+* [Swift Development Environment](https://github.com/vknabel/vscode-swift-development-environment): a vscode plugin for Swift including **autocompletion**. _Supports Linux and Darwin._
 * [Sourcery](https://github.com/krzysztofzablocki/Sourcery): a command-line tool for **metaprogramming** for Swift. Runs on Darwin. Linux support is [planned](https://github.com/krzysztofzablocki/Sourcery/milestone/2).
 * [Stencil](https://github.com/kylef/Stencil): a **templating** engine inspired by Django and Mustache.
-* [SwiftLint](https://github.com/realm/SwiftLint): a command-line tool to **lint** your Swift code. Runs on Darwin and Linux.
+* [SwiftLint](https://github.com/realm/SwiftLint): a command-line tool to **lint** your Swift code.
 
 #### Other Developer Tools
 > _Tags: scripting, metadata, project, install_
-* [Archery](https://github.com/vknabel/Archery): a Swift framework and command-line tool to **manage** your projects' **metadata**. Runs on Darwin and Linux.
-* [Marathon](https://github.com/JohnSundell/Marathon): a command-line tool to **run and manage** Swift scripts. Runs on Darwin and Linux.
-* [Mint](https://github.com/yonaskolb/Mint): a Swift framework and command-line tool to **run and install** Swift Package Manager **command-line tools**. Runs on Darwin and Linux.
+* [Archery](https://github.com/vknabel/Archery): a Swift framework and command-line tool to **manage** your projects' **metadata**.
+* [Marathon](https://github.com/JohnSundell/Marathon): a command-line tool to **run and manage** Swift scripts.
+* [Mint](https://github.com/yonaskolb/Mint): a Swift framework and command-line tool to **run and install** Swift Package Manager **command-line tools**.
 * [Workspace](https://github.com/SDGGiesbrecht/Workspace#workspace): a command‐line tool for centralized **validation and maintenance** of Swift packages.
 
 ### Web Libraries

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Our objective is to feature cross-platform libraries, designed for wherever Swif
 
 ## The Index
 
+**Note:** every library listed here is supported both on Darwin and Linux, unless noted otherwise.
+
 ### Command Line UI tools
 > _Tags: parsing, CLI, arguments, command, console, terminal, shell_
 * [CLSwift](https://github.com/twof/CLSwift): Framework for **writing command-line tools** in Swift. Includes type safe argument parsing, input validation, and generated help messages.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Our objective is to feature cross-platform libraries, designed for wherever Swif
 * [Vapor-Console](https://github.com/vapor/console): provides APIs for performing **console I/O**, including outputting stylized text, requesting user input, and displaying activity indicators like loading bars.
 
 ### Workflow-enabler Frameworks
+
 #### Asyncronous and Reactive Programming
 > *Tags: reactive, promise, async, result*
 * [AsyncNinja](https://github.com/AsyncNinja/AsyncNinja): primitives for enabling concurrency and reactive programming.
@@ -47,6 +48,11 @@ Our objective is to feature cross-platform libraries, designed for wherever Swif
 * [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift): cross platform, **reactive** programming. `Result + async + Sequence = ReactiveSwift`
 * [Result](https://github.com/antitypical/Result): microframework for modeling and handling errors in code.
 * [RxSwift](https://github.com/ReactiveX/RxSwift): **reactive** programming in Swift.<sup>[1](#footnote_testing_rxSwift)</sup>
+
+#### Logging and Tracing
+> _Tags: logging, debugging, trace_
+* [TraceLog](https://github.com/tonystone/tracelog): A debug and trace logging framework.
+
 #### Testing and Behavior Driven Development
 > *Tags: BDD, testing, quickcheck, property*
 * [Nimble](https://github.com/Quick/Nimble): **matcher** and **testing** counterpart for Quick.
@@ -120,10 +126,6 @@ Our objective is to feature cross-platform libraries, designed for wherever Swif
 ### Foundation Extensions
 > _Tags: localization, preferences, random, precision, pattern matching_
 * [SDGCornerstone](https://github.com/SDGGiesbrecht/SDGCornerstone#sdgcornerstone): cross‐platform, full‐grammar **localization**; cross‐platform, bindable **preferences**; generic **pattern matching**; **randomization**; **arbitrary‐precision arithmetic**; etc.
-
-#### Logging libraries
-> _Tags: logging, logging-libraries, debug, debugging, trace_
-* [TraceLog](https://github.com/tonystone/tracelog): A debug and trace logging framework. Runs on ios, osx, and linux.
 
 ---
 


### PR DESCRIPTION
Since so many _do_ support Linux, I think we should make it implicit... and maybe make a statement in the first lines of the document?

But anyway, the thing is, most of the libs listed here do support Linux already. The ones we're listing that don't are few, and are working on it. I think we can omit the "Runs on Darwin and Linux" part because most of them do. We can include that part if it's maybe necessary for reassurance, like for SDE, which is surrounded by libs which aren't complete on Linux yet.

What do you think?